### PR TITLE
Etunimetensin

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -198,7 +198,7 @@ module ApplicationHelper
   end
 
   def full_name(competitor, first_name_first=false)
-    if first_name_first
+    if first_name_first or always_first_name_first?
       "#{competitor.first_name} #{competitor.last_name}"
     else
       "#{competitor.last_name} #{competitor.first_name}"
@@ -384,5 +384,9 @@ module ApplicationHelper
 
   def result_rotation_cookie
     return cookies['seriescount']
+  end
+
+  def always_first_name_first?
+    return ALWAYS_FIRST_NAME_FIRST
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,8 @@ ADMIN_EMAIL = ["com", ".", "karhatsu", "@", "henri"].reverse.join('')
 TEST_URL = "http://hutesti.heroku.com"
 PRODUCTION_URL = "http://www.hirviurheilu.com"
 
+ALWAYS_FIRST_NAME_FIRST = true
+
 OFFLINE = false
 ONLINE = !OFFLINE
 

--- a/spec/helpers/application_helper_spec.rb
+++ b/spec/helpers/application_helper_spec.rb
@@ -421,12 +421,31 @@ describe ApplicationHelper do
   end
 
   describe "#full_name" do
-    specify { helper.full_name(mock_model(Competitor, :last_name => "Tester",
-        :first_name => "Tim")).should == "Tester Tim" }
-
-    describe "first name first" do
+    context "when ALWAYS_FIRST_NAME_FIRST not set" do
+      before do
+        helper.stub!(:always_first_name_first?).and_return(false)
+      end
       specify { helper.full_name(mock_model(Competitor, :last_name => "Tester",
-          :first_name => "Tim"), true).should == "Tim Tester" }
+                      :first_name => "Tim")).should == "Tester Tim" }
+
+      describe "first name first" do
+        specify { helper.full_name(mock_model(Competitor, :last_name => "Tester",
+                                              :first_name => "Tim"), true).should == "Tim Tester" }
+      end
+    end
+
+    context "when ALWAYS_FIRST_NAME_FIRST set" do
+      before do
+        helper.stub!(:always_first_name_first?).and_return(true)
+      end
+      specify { helper.full_name(mock_model(Competitor, :last_name => "Tester",
+                      :first_name => "Tim")).should == "Tim Tester" }
+
+      describe "first name first" do
+        
+        specify { helper.full_name(mock_model(Competitor, :last_name => "Tester",
+                                              :first_name => "Tim"), true).should == "Tim Tester" }
+      end
     end
   end
 


### PR DESCRIPTION
Olit jo tehnyt helper-metodiin sen etunimi ensin -kohdan. Sen sijaan että olisin muokannut kymmentä kohtaa view-puolella, tein helper-metodiin lisäehdon joka määrittää, että etunimi on aina ensin. Tämän metodi käyttää sovellusvakiota, jolloin oletusta on helppo muuttaa yhtä paikkaa muuttamalla. Ja on helppo lisätä konfiguroitavuus käyttäjälle jos haluat.
